### PR TITLE
Reduces transparency of vishraams

### DIFF
--- a/src/scss/themes/helpers/_theme-generator.scss
+++ b/src/scss/themes/helpers/_theme-generator.scss
@@ -33,7 +33,7 @@
         background: linear-gradient(
           to right,
           rgba(229, 229, 229, 0) 20%,
-          rgba($visraam-main, 0.5) 100%
+          rgba($visraam-main, 0.7) 100%
         );
       }
 
@@ -41,7 +41,7 @@
         background: linear-gradient(
           to right,
           rgba(229, 229, 229, 0) 20%,
-          rgba($visraam-yamki, 0.5) 100%
+          rgba($visraam-yamki, 0.7) 100%
         );
       }
     }


### PR DESCRIPTION
Reduces transparency of vishraams by 2 points so that there's higher contrast in themes like Moody Blue. Other than that there was no difference between colors provided by aman veerji and what was coded. 