### PR TITLE
hides translation, transliteration and teeka in announcement slide

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -136,6 +136,13 @@ body {
     display: flex;
     height: 100vh;
     justify-content: center;
+
+    #translation,
+    #transliteration,
+    #teeka,
+    #next-line {
+      display: none;
+    }
   }
 
   &.active {


### PR DESCRIPTION
Chromecast was showing all of them in the the announcement slide. 